### PR TITLE
Create canvas interface

### DIFF
--- a/src/classes/Canvas.ts
+++ b/src/classes/Canvas.ts
@@ -1,0 +1,36 @@
+import { ICanvas } from '../interfaces/ICanvas';
+
+export class Canvas implements ICanvas {
+    private canvas: HTMLCanvasElement;
+    private context: CanvasRenderingContext2D;
+
+    constructor(canvas: HTMLCanvasElement) {
+        this.canvas = canvas;
+        this.context = canvas.getContext('2d')!;
+    }
+
+    drawLine(x1: number, y1: number, x2: number, y2: number): void {
+        this.context.beginPath();
+        this.context.moveTo(x1, y1);
+        this.context.lineTo(x2, y2);
+        this.context.stroke();
+    }
+
+    drawCircle(x: number, y: number, radius: number): void {
+        this.context.beginPath();
+        this.context.arc(x, y, radius, 0, Math.PI * 2);
+        this.context.stroke();
+    }
+
+    drawRect(x: number, y: number, width: number, height: number): void {
+        this.context.strokeRect(x, y, width, height);
+    }
+
+    fillRect(x: number, y: number, width: number, height: number): void {
+        this.context.fillRect(x, y, width, height);
+    }
+
+    getBaseCanvas(): HTMLCanvasElement {
+        return this.canvas;
+    }
+}

--- a/src/interfaces/ICanvas.ts
+++ b/src/interfaces/ICanvas.ts
@@ -1,0 +1,7 @@
+export interface ICanvas {
+    drawLine(x1: number, y1: number, x2: number, y2: number): void;
+    drawCircle(x: number, y: number, radius: number): void;
+    drawRect(x: number, y: number, width: number, height: number): void;
+    fillRect(x: number, y: number, width: number, height: number): void;
+    getBaseCanvas(): HTMLCanvasElement;
+}

--- a/src/tests/Canvas.test.ts
+++ b/src/tests/Canvas.test.ts
@@ -1,0 +1,61 @@
+import { Canvas } from '../classes/Canvas';
+
+describe('Canvas', () => {
+    let canvasElement: HTMLCanvasElement;
+    let canvas: Canvas;
+
+    beforeEach(() => {
+        canvasElement = document.createElement('canvas');
+        canvas = new Canvas(canvasElement);
+    });
+
+    test('drawLine', () => {
+        const context = canvasElement.getContext('2d')!;
+        jest.spyOn(context, 'beginPath');
+        jest.spyOn(context, 'moveTo');
+        jest.spyOn(context, 'lineTo');
+        jest.spyOn(context, 'stroke');
+
+        canvas.drawLine(10, 10, 100, 100);
+
+        expect(context.beginPath).toHaveBeenCalled();
+        expect(context.moveTo).toHaveBeenCalledWith(10, 10);
+        expect(context.lineTo).toHaveBeenCalledWith(100, 100);
+        expect(context.stroke).toHaveBeenCalled();
+    });
+
+    test('drawCircle', () => {
+        const context = canvasElement.getContext('2d')!;
+        jest.spyOn(context, 'beginPath');
+        jest.spyOn(context, 'arc');
+        jest.spyOn(context, 'stroke');
+
+        canvas.drawCircle(50, 50, 20);
+
+        expect(context.beginPath).toHaveBeenCalled();
+        expect(context.arc).toHaveBeenCalledWith(50, 50, 20, 0, Math.PI * 2);
+        expect(context.stroke).toHaveBeenCalled();
+    });
+
+    test('drawRect', () => {
+        const context = canvasElement.getContext('2d')!;
+        jest.spyOn(context, 'strokeRect');
+
+        canvas.drawRect(20, 20, 60, 60);
+
+        expect(context.strokeRect).toHaveBeenCalledWith(20, 20, 60, 60);
+    });
+
+    test('fillRect', () => {
+        const context = canvasElement.getContext('2d')!;
+        jest.spyOn(context, 'fillRect');
+
+        canvas.fillRect(30, 30, 40, 40);
+
+        expect(context.fillRect).toHaveBeenCalledWith(30, 30, 40, 40);
+    });
+
+    test('getBaseCanvas', () => {
+        expect(canvas.getBaseCanvas()).toBe(canvasElement);
+    });
+});

--- a/src/views/SomeView.ts
+++ b/src/views/SomeView.ts
@@ -1,0 +1,17 @@
+import { ICanvas } from '../interfaces/ICanvas';
+import { Canvas } from '../classes/Canvas';
+
+class SomeView {
+    private canvas: ICanvas;
+
+    constructor(canvasElement: HTMLCanvasElement) {
+        this.canvas = new Canvas(canvasElement);
+    }
+
+    draw() {
+        this.canvas.drawLine(10, 10, 100, 100);
+        this.canvas.drawCircle(50, 50, 20);
+        this.canvas.drawRect(20, 20, 60, 60);
+        this.canvas.fillRect(30, 30, 40, 40);
+    }
+}


### PR DESCRIPTION
Related to #20

Add a canvas interface and implement it in a Canvas class to replace standard canvas and context objects.

* **ICanvas Interface**
  - Define `ICanvas` interface with methods for drawing operations: `drawLine`, `drawCircle`, `drawRect`, `fillRect`.
  - Add method `getBaseCanvas` to return the base canvas for special cases.

* **Canvas Class**
  - Implement `ICanvas` interface in `Canvas` class.
  - Use standard canvas and context objects internally.
  - Implement methods: `drawLine`, `drawCircle`, `drawRect`, `fillRect`.
  - Add method `getBaseCanvas` to return the base canvas for special cases.

* **SomeView Class**
  - Replace standard canvas and context objects with `ICanvas` interface.
  - Update drawing operations to use `ICanvas` methods.

* **Canvas Tests**
  - Add unit tests for `Canvas` class implementing `ICanvas` interface.
  - Test methods: `drawLine`, `drawCircle`, `drawRect`, `fillRect`.
  - Test method `getBaseCanvas` to return the base canvas for special cases.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PiotrSquaresMoscicki/AbstractionGraph/issues/20?shareId=1c398b46-f147-41f4-b8e2-70743a9e358b).